### PR TITLE
Tentative fixes for SBCL compiler noise/some missed optimizations.

### DIFF
--- a/hashtable.lisp
+++ b/hashtable.lisp
@@ -533,13 +533,9 @@
               do (setf r (%chm-resizers chm)))
         ;; Size calculation: 2 words per table + extra
         ;; NOTE: The original assumes 32 bit pointers, we conditionalise
-        (let ((megs
-                ;; FIXME: Not sure what to do here to get rid of the
-                ;; intermediary bignum in the generated code.
-                (locally (declare (optimize (speed 1)))
-                  (ash (ash (+ (* size 2) 4)
+        (let ((megs (ash (ash (+ (* size 2) 4)
                             #+64-BIT 4 #-64-BIT 3)
-                       -20))))
+                       -20)))
           (declare (type fixnum megs))
           (when (and (<= 2 r) (< 0 megs))
             (setf newkvs (%chm-newkvs chm))

--- a/list.lisp
+++ b/list.lisp
@@ -100,16 +100,7 @@
   (declare (optimize speed))
   (let ((tail (tail list)))
     (loop (multiple-value-bind (right left) (search-cons value list)
-            (when (or (eq right tail) (not
-                                       ;; TODO: This avoids a generic EQL
-                                       ;; function being emitted as a compiler
-                                       ;; note. This may be avoidable, but VALUE
-                                       ;; can be any type, so just temporarily
-                                       ;; resetting the speed optimization until
-                                       ;; a better solution arises.
-                                       (let ((right-car (car* right)))
-                                         (locally (declare (optimize (speed 1)))
-                                           (eql value right-car)))))
+            (when (or (eq right tail) (not (eql value (car* right))))
               (return list))
             (let ((next (cdr* right)))
               (when (and (= 1 (valid right))
@@ -123,10 +114,7 @@
   (declare (optimize speed))
   (let ((right (search-cons value list)))
     (and (not (eq right (tail list)))
-         (let ((right-car (car* right)))
-           ;; FIXME: Again, same reason.
-           (locally (declare (optimize (speed 1)))
-             (eql right-car value))))))
+         (eql (car* right) value))))
 
 (defun search-cons (value list)
   (declare (type caslist list))
@@ -145,10 +133,7 @@
                        (return))
                      (setf next (cdr* cons))
                   while (or (= 0 (valid cons))
-                            (let ((cons-car (car* cons)))
-                              ;; FIXME: And again, same reason.
-                              (locally (declare (optimize (speed 1)))
-                                (not (eql cons-car value))))))
+                            (not (eql (car* cons) value))))
             (setf right cons)
             (when (or (eq left-next right)
                       (cas (cdr* left) left-next right))


### PR DESCRIPTION
Before this PR, loading luckless with a clear cache and ASDF verbosity on, results in a lot of output, ending with:

;;   caught 1 WARNING condition
;;   caught 6 STYLE-WARNING conditions
;;   printed 26 notes

After this PR is applied, the noise is much less, and ends with:

;;   caught 3 STYLE-WARNING conditions
;;   printed 7 notes

Most of the noise were STYLE-WARNINGs which I mostly ignored, for stuff like &optional and &key in the same lambda list.

Some things were just missing type declarations.

Some things I was not sure about, and I noted them in comments. I temporarily locally declared the speed optimization quality back to 1 in the few places it was unhappy about types, generating generic code, that should be looked into.

In one particular case, a constant variable defined in hashtable.lisp was being referenced in cat.lisp, even though the file ordering prevented there even being a variable at compile time. I moved that one variable to the other file.

There is more work to do, and this definitely shouldn't be merged as is, but it's a start.